### PR TITLE
Suggested a fix for readStrz that embeds chr() into function

### DIFF
--- a/lib/Kaitai/Struct/Stream.php
+++ b/lib/Kaitai/Struct/Stream.php
@@ -242,7 +242,8 @@ class Stream {
         return $this->bytesToEncoding($this->readBytes($numberOfBytes), $outputEncoding);
     }
 
-    public function readStrz(string $outputEncoding, string $terminator, bool $includeTerminator, bool $consumeTerminator, bool $eosError): string {
+    public function readStrz(string $outputEncoding, int $terminator, bool $includeTerminator, bool $consumeTerminator, bool $eosError): string {
+        $termStr = chr($terminator);
         $bytes = '';
         while (true) {
             if ($this->isEof()) {
@@ -252,7 +253,7 @@ class Stream {
                 break;
             }
             $byte = $this->readBytes(1);
-            if ($byte === $terminator) {
+            if ($byte === $termStr) {
                 if ($includeTerminator) {
                     $bytes .= $byte;
                 }


### PR DESCRIPTION
This ought to fix repeatUntilS4 test (and other tests that use `strz` type).
