### PR TITLE
A fix for isEof() function to adhere to semantics used by default in KS

### DIFF
--- a/lib/Kaitai/Struct/Stream.php
+++ b/lib/Kaitai/Struct/Stream.php
@@ -24,7 +24,21 @@ class Stream {
      **************************************************************************/
 
     public function isEof(): bool {
-        return feof($this->stream);
+        // Unfortunately, feof() documentation in PHP is very unclear and,
+        // in fact, its semantics follows C++ semantics with "read at least once
+        // past the EOF first" => "set EOF flag on stream" => "eof returns true".
+        // So, we'll have to emulate the same "one byte lookup" pattern from C++.
+
+        if (fgetc($this->stream) === FALSE) {
+            // reached EOF
+            return TRUE;
+        } else {
+            // restore stream position, 1 byte back
+            if (fseek($this->stream, -1, SEEK_CUR) !== 0) {
+                throw new \RuntimeException("Unable to roll back after reading a byte in isEof");
+            }
+            return FALSE;
+        }
     }
 
     /**


### PR DESCRIPTION
eof should returns "true" when pointer is at the end of the stream, _not_ when it was at the end of the stream + at least one (failed) read attempt was done after that.

For more details, see the comments in file and refer to http://php.net/manual/ru/function.feof.php#67261
