### PR TITLE
Add custom exceptions

### DIFF
--- a/lib/Kaitai/Struct/Error/EOFError.php
+++ b/lib/Kaitai/Struct/Error/EOFError.php
@@ -1,0 +1,13 @@
+<?php
+namespace Kaitai\Struct\Error;
+
+class EOFError extends \RuntimeException {
+    protected $bytesReq;
+    protected $bytesAvail;
+
+    public function __construct(int $bytesReq, int $bytesAvail) {
+        parent::__construct('Requested ' . $bytesReq . ' bytes, but only ' . $bytesAvail . ' bytes available');
+        $this->bytesReq = $bytesReq;
+        $this->bytesAvail = $bytesAvail;
+    }
+}

--- a/lib/Kaitai/Struct/Error/EndOfStreamError.php
+++ b/lib/Kaitai/Struct/Error/EndOfStreamError.php
@@ -1,7 +1,7 @@
 <?php
 namespace Kaitai\Struct\Error;
 
-class EndOfStreamError extends \RuntimeException {
+class EndOfStreamError extends KaitaiError {
     protected $bytesReq;
     protected $bytesAvail;
 

--- a/lib/Kaitai/Struct/Error/EndOfStreamError.php
+++ b/lib/Kaitai/Struct/Error/EndOfStreamError.php
@@ -1,7 +1,7 @@
 <?php
 namespace Kaitai\Struct\Error;
 
-class EOFError extends \RuntimeException {
+class EndOfStreamError extends \RuntimeException {
     protected $bytesReq;
     protected $bytesAvail;
 

--- a/lib/Kaitai/Struct/Error/KaitaiError.php
+++ b/lib/Kaitai/Struct/Error/KaitaiError.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Kaitai\Struct\Error;
+
+class KaitaiError extends \RuntimeException
+{
+}

--- a/lib/Kaitai/Struct/Error/KaitaiStructError.php
+++ b/lib/Kaitai/Struct/Error/KaitaiStructError.php
@@ -1,0 +1,11 @@
+<?php
+namespace Kaitai\Struct\Error;
+
+class KaitaiStructError extends \RuntimeException {
+    protected $srcPath;
+
+    public function __construct(string $msg, string $srcPath) {
+        parent::__construct($srcPath . ': ' . $msg);
+        $this->srcPath = $srcPath;
+    }
+}

--- a/lib/Kaitai/Struct/Error/KaitaiStructError.php
+++ b/lib/Kaitai/Struct/Error/KaitaiStructError.php
@@ -1,7 +1,7 @@
 <?php
 namespace Kaitai\Struct\Error;
 
-class KaitaiStructError extends \RuntimeException {
+class KaitaiStructError extends KaitaiError {
     protected $srcPath;
 
     public function __construct(string $msg, string $srcPath) {

--- a/lib/Kaitai/Struct/Error/NoTerminatorFoundError.php
+++ b/lib/Kaitai/Struct/Error/NoTerminatorFoundError.php
@@ -1,0 +1,11 @@
+<?php
+namespace Kaitai\Struct\Error;
+
+class NoTerminatorFoundError extends \RuntimeException {
+    protected $terminator;
+
+    public function __construct(string $terminator) {
+        parent::__construct("End of stream reached, but no terminator '$terminator' found");
+        $this->terminator = $terminator;
+    }
+}

--- a/lib/Kaitai/Struct/Error/NoTerminatorFoundError.php
+++ b/lib/Kaitai/Struct/Error/NoTerminatorFoundError.php
@@ -1,7 +1,7 @@
 <?php
 namespace Kaitai\Struct\Error;
 
-class NoTerminatorFoundError extends \RuntimeException {
+class NoTerminatorFoundError extends KaitaiError {
     protected $terminator;
 
     public function __construct(string $terminator) {

--- a/lib/Kaitai/Struct/Error/NotSupportedPlatformError.php
+++ b/lib/Kaitai/Struct/Error/NotSupportedPlatformError.php
@@ -1,0 +1,4 @@
+<?php
+namespace Kaitai\Struct\Error;
+
+class NotSupportedPlatformError extends \RuntimeException {}

--- a/lib/Kaitai/Struct/Error/NotSupportedPlatformError.php
+++ b/lib/Kaitai/Struct/Error/NotSupportedPlatformError.php
@@ -1,4 +1,4 @@
 <?php
 namespace Kaitai\Struct\Error;
 
-class NotSupportedPlatformError extends \RuntimeException {}
+class NotSupportedPlatformError extends KaitaiError {}

--- a/lib/Kaitai/Struct/Error/ProcessError.php
+++ b/lib/Kaitai/Struct/Error/ProcessError.php
@@ -1,0 +1,4 @@
+<?php
+namespace Kaitai\Struct\Error;
+
+class ProcessError extends \RuntimeException {}

--- a/lib/Kaitai/Struct/Error/ProcessError.php
+++ b/lib/Kaitai/Struct/Error/ProcessError.php
@@ -1,4 +1,4 @@
 <?php
 namespace Kaitai\Struct\Error;
 
-class ProcessError extends \RuntimeException {}
+class ProcessError extends KaitaiError {}

--- a/lib/Kaitai/Struct/Error/RotateProcessError.php
+++ b/lib/Kaitai/Struct/Error/RotateProcessError.php
@@ -1,0 +1,4 @@
+<?php
+namespace Kaitai\Struct\Error;
+
+class RotateProcessError extends ProcessError {}

--- a/lib/Kaitai/Struct/Error/UndecidedEndiannessError.php
+++ b/lib/Kaitai/Struct/Error/UndecidedEndiannessError.php
@@ -1,7 +1,7 @@
 <?php
 namespace Kaitai\Struct\Error;
 
-class UndecidedEndiannessError extends \RuntimeException {
+class UndecidedEndiannessError extends KaitaiError {
     public function __construct() {
         parent::__construct('Unable to decide on endianness');
     }

--- a/lib/Kaitai/Struct/Error/UndecidedEndiannessError.php
+++ b/lib/Kaitai/Struct/Error/UndecidedEndiannessError.php
@@ -1,0 +1,8 @@
+<?php
+namespace Kaitai\Struct\Error;
+
+class UndecidedEndiannessError extends \RuntimeException {
+    public function __construct() {
+        parent::__construct('Unable to decide on endianness');
+    }
+}

--- a/lib/Kaitai/Struct/Error/ValidationFailedError.php
+++ b/lib/Kaitai/Struct/Error/ValidationFailedError.php
@@ -1,0 +1,17 @@
+<?php
+namespace Kaitai\Struct\Error;
+
+use \Kaitai\Struct\Stream;
+
+/**
+ * Common ancestor for all validation failures. Stores pointer to
+ * KaitaiStream IO object which was involved in an error.
+ */
+class ValidationFailedError extends KaitaiStructError {
+    protected $io;
+
+    public function __construct(string $msg, Stream $io, string $srcPath) {
+        parent::__construct('at pos ' . $io->pos() . ': validation failed: ' . $msg, $srcPath);
+        $this->io = $io;
+    }
+}

--- a/lib/Kaitai/Struct/Error/ValidationGreaterThanError.php
+++ b/lib/Kaitai/Struct/Error/ValidationGreaterThanError.php
@@ -1,0 +1,15 @@
+<?php
+namespace Kaitai\Struct\Error;
+
+use Kaitai\Struct\Stream;
+
+class ValidationGreaterThanError extends ValidationFailedError {
+    protected $max;
+    protected $actual;
+
+    public function __construct($max, $actual, Stream $io, string $srcPath) {
+        parent::__construct('not in range, max ' . print_r($max, true) . ', but got ' . print_r($actual, true), $io, $srcPath);
+        $this->max = $max;
+        $this->actual = $actual;
+    }
+}

--- a/lib/Kaitai/Struct/Error/ValidationLessThanError.php
+++ b/lib/Kaitai/Struct/Error/ValidationLessThanError.php
@@ -1,0 +1,15 @@
+<?php
+namespace Kaitai\Struct\Error;
+
+use Kaitai\Struct\Stream;
+
+class ValidationLessThanError extends ValidationFailedError {
+    protected $min;
+    protected $actual;
+
+    public function __construct($min, $actual, Stream $io, string $srcPath) {
+        parent::__construct('not in range, min ' . print_r($min, true) . ', but got ' . print_r($actual, true), $io, $srcPath);
+        $this->min = $min;
+        $this->actual = $actual;
+    }
+}

--- a/lib/Kaitai/Struct/Error/ValidationNotAnyOfError.php
+++ b/lib/Kaitai/Struct/Error/ValidationNotAnyOfError.php
@@ -1,0 +1,13 @@
+<?php
+namespace Kaitai\Struct\Error;
+
+use Kaitai\Struct\Stream;
+
+class ValidationNotAnyOfError extends ValidationFailedError {
+    protected $actual;
+
+    public function __construct($actual, Stream $io, string $srcPath) {
+        parent::__construct('not any of the list, got ' . print_r($actual, true), $io, $srcPath);
+        $this->actual = $actual;
+    }
+}

--- a/lib/Kaitai/Struct/Error/ValidationNotEqualError.php
+++ b/lib/Kaitai/Struct/Error/ValidationNotEqualError.php
@@ -1,0 +1,15 @@
+<?php
+namespace Kaitai\Struct\Error;
+
+use Kaitai\Struct\Stream;
+
+class ValidationNotEqualError extends ValidationFailedError {
+    protected $expected;
+    protected $actual;
+
+    public function __construct($expected, $actual, Stream $io, string $srcPath) {
+        parent::__construct('not equal, expected ' . print_r($expected, true) . ', but got ' . print_r($actual, true), $io, $srcPath);
+        $this->expected = $expected;
+        $this->actual = $actual;
+    }
+}

--- a/lib/Kaitai/Struct/Error/ZlibProcessError.php
+++ b/lib/Kaitai/Struct/Error/ZlibProcessError.php
@@ -1,0 +1,4 @@
+<?php
+namespace Kaitai\Struct\Error;
+
+class ZlibProcessError extends ProcessError {}

--- a/lib/Kaitai/Struct/Stream.php
+++ b/lib/Kaitai/Struct/Stream.php
@@ -1,6 +1,8 @@
 <?php
 namespace Kaitai\Struct;
 
+use Kaitai\Struct\Error\EOFError;
+
 class Stream {
     protected $stream;
 
@@ -261,7 +263,7 @@ class Stream {
         $bytes = fread($this->stream, $numberOfBytes);
         $n = strlen($bytes);
         if ($n < $numberOfBytes) {
-            throw new \RuntimeException("Requested $numberOfBytes bytes, but got only $n bytes");
+            throw new EOFError($numberOfBytes, $n);
         }
         return $bytes;
     }

--- a/lib/Kaitai/Struct/Stream.php
+++ b/lib/Kaitai/Struct/Stream.php
@@ -2,6 +2,7 @@
 namespace Kaitai\Struct;
 
 use Kaitai\Struct\Error\EOFError;
+use Kaitai\Struct\Error\NotSupportedPlatformError;
 
 class Stream {
     protected $stream;
@@ -17,7 +18,7 @@ class Stream {
      */
     public function __construct($stream) {
         if (PHP_INT_SIZE !== 8) {
-            throw new \RuntimeException("Only 64-bit platform is implemented");
+            throw new NotSupportedPlatformError("Only 64-bit platform is implemented");
         }
         if (is_string($stream)) {
             $this->stream = fopen('php://memory', 'r+b');

--- a/lib/Kaitai/Struct/Stream.php
+++ b/lib/Kaitai/Struct/Stream.php
@@ -1,7 +1,7 @@
 <?php
 namespace Kaitai\Struct;
 
-use Kaitai\Struct\Error\EOFError;
+use Kaitai\Struct\Error\EndOfStreamError;
 use Kaitai\Struct\Error\NoTerminatorFoundError;
 use Kaitai\Struct\Error\NotSupportedPlatformError;
 use Kaitai\Struct\Error\RotateProcessError;
@@ -267,7 +267,7 @@ class Stream {
         $bytes = fread($this->stream, $numberOfBytes);
         $n = strlen($bytes);
         if ($n < $numberOfBytes) {
-            throw new EOFError($numberOfBytes, $n);
+            throw new EndOfStreamError($numberOfBytes, $n);
         }
         return $bytes;
     }

--- a/lib/Kaitai/Struct/Stream.php
+++ b/lib/Kaitai/Struct/Stream.php
@@ -297,6 +297,9 @@ class Stream {
         return $bytes;
     }
 
+    /**
+     * @deprecated Unused since Kaitai Struct Compiler v0.9+ - compatibility with older versions
+     */
     public function ensureFixedContents(string $expectedBytes): string {
         $length = strlen($expectedBytes);
         $bytes = $this->readBytes($length);

--- a/lib/Kaitai/Struct/Stream.php
+++ b/lib/Kaitai/Struct/Stream.php
@@ -3,6 +3,8 @@ namespace Kaitai\Struct;
 
 use Kaitai\Struct\Error\EOFError;
 use Kaitai\Struct\Error\NotSupportedPlatformError;
+use Kaitai\Struct\Error\RotateProcessError;
+use Kaitai\Struct\Error\ZlibProcessError;
 
 class Stream {
     protected $stream;
@@ -373,7 +375,7 @@ class Stream {
 
     public static function processRotateLeft(string $bytes, int $amount, int $groupSize): string {
         if ($groupSize !== 1) {
-            throw new \RuntimeException("Unable to rotate group of $groupSize bytes yet");
+            throw new RotateProcessError("Unable to rotate group of $groupSize bytes yet");
         }
         $rotated = '';
         for ($i = 0, $n = strlen($bytes); $i < $n; $i++) {
@@ -388,7 +390,7 @@ class Stream {
         if (false === $uncompressed) {
             $error = error_get_last();
             error_clear_last();
-            throw new \RuntimeException($error['message']);
+            throw new ZlibProcessError($error['message']);
         }
         return $uncompressed;
     }

--- a/lib/Kaitai/Struct/Stream.php
+++ b/lib/Kaitai/Struct/Stream.php
@@ -2,6 +2,7 @@
 namespace Kaitai\Struct;
 
 use Kaitai\Struct\Error\EOFError;
+use Kaitai\Struct\Error\NoTerminatorFoundError;
 use Kaitai\Struct\Error\NotSupportedPlatformError;
 use Kaitai\Struct\Error\RotateProcessError;
 use Kaitai\Struct\Error\ZlibProcessError;
@@ -283,7 +284,7 @@ class Stream {
         while (true) {
             if ($this->isEof()) {
                 if ($eosError) {
-                    throw new \RuntimeException("End of stream reached, but no terminator '$terminator' found");
+                    throw new NoTerminatorFoundError($terminator);
                 }
                 break;
             }

--- a/lib/Kaitai/Struct/Stream.php
+++ b/lib/Kaitai/Struct/Stream.php
@@ -2,6 +2,7 @@
 namespace Kaitai\Struct;
 
 use Kaitai\Struct\Error\EndOfStreamError;
+use Kaitai\Struct\Error\KaitaiError;
 use Kaitai\Struct\Error\NoTerminatorFoundError;
 use Kaitai\Struct\Error\NotSupportedPlatformError;
 use Kaitai\Struct\Error\RotateProcessError;
@@ -54,7 +55,7 @@ class Stream {
         } else {
             // restore stream position, 1 byte back
             if (fseek($this->stream, -1, SEEK_CUR) !== 0) {
-                throw new \RuntimeException("Unable to roll back after reading a byte in isEof");
+                throw new KaitaiError("Unable to roll back after reading a byte in isEof");
             }
             return false;
         }
@@ -66,11 +67,11 @@ class Stream {
     public function seek(int $pos)/*: void */ {
         $size = $this->size();
         if ($pos > $size) {
-            throw new \RuntimeException("The position ($pos) must be less than the size ($size) of the stream");
+            throw new KaitaiError("The position ($pos) must be less than the size ($size) of the stream");
         }
         $res = fseek($this->stream, $pos);
         if ($res !== 0) {
-            throw new \RuntimeException("Unable to set new position");
+            throw new KaitaiError("Unable to set new position");
         }
     }
 

--- a/test/KaitaiTest/Struct/StreamTest.php
+++ b/test/KaitaiTest/Struct/StreamTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace KaitaiTest\Struct;
 
+use Kaitai\Struct\Error\EOFError;
 use Kaitai\Struct\Stream;
 use PHPUnit\Framework\TestCase;
 
@@ -391,8 +392,8 @@ class StreamTest extends TestCase {
         try {
             $stream->ensureFixedContents($bytes);
             $this->fail();
-        } catch (\RuntimeException $e) {
-            $this->assertEquals('Requested ' . strlen($bytes) . ' bytes, but got only 0 bytes', $e->getMessage());
+        } catch (EOFError $e) {
+            $this->assertEquals('Requested ' . strlen($bytes) . ' bytes, but only 0 bytes available', $e->getMessage());
         }
     }
 

--- a/test/KaitaiTest/Struct/StreamTest.php
+++ b/test/KaitaiTest/Struct/StreamTest.php
@@ -344,7 +344,7 @@ class StreamTest extends TestCase {
         // @TODO: test NAN, -INF, INF, -0.0, 0.0
     }
 
-    public function testReadBytes_Сonsistently() {
+    public function testReadBytes_Consistently() {
         $bytes = "\x03\xef\xa4\xb9";
         $stream = new Stream($bytes);
         $this->assertEquals("\x03\xef", $stream->readBytes(2));

--- a/test/KaitaiTest/Struct/StreamTest.php
+++ b/test/KaitaiTest/Struct/StreamTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace KaitaiTest\Struct;
 
-use Kaitai\Struct\Error\EOFError;
+use Kaitai\Struct\Error\EndOfStreamError;
 use Kaitai\Struct\Stream;
 use PHPUnit\Framework\TestCase;
 
@@ -392,7 +392,7 @@ class StreamTest extends TestCase {
         try {
             $stream->ensureFixedContents($bytes);
             $this->fail();
-        } catch (EOFError $e) {
+        } catch (EndOfStreamError $e) {
             $this->assertEquals('Requested ' . strlen($bytes) . ' bytes, but only 0 bytes available', $e->getMessage());
         }
     }

--- a/test/KaitaiTest/Struct/StreamTest.php
+++ b/test/KaitaiTest/Struct/StreamTest.php
@@ -2,6 +2,7 @@
 namespace KaitaiTest\Struct;
 
 use Kaitai\Struct\Error\EndOfStreamError;
+use Kaitai\Struct\Error\KaitaiError;
 use Kaitai\Struct\Stream;
 use PHPUnit\Framework\TestCase;
 
@@ -460,7 +461,7 @@ class StreamTest extends TestCase {
         try {
             $this->assertNull($stream->seek($pos));
             $this->fail();
-        } catch (\RuntimeException $e) {
+        } catch (KaitaiError $e) {
             $this->assertRegExp("~The position \\($pos\\) must be less than the size \\(\\d+\\) of the stream~s", $e->getMessage());
         }
     }


### PR DESCRIPTION
I added all the `Validation*` exceptions to comply with kaitai-io/kaitai_struct#435. The next thing I'll do is to make the compiler throw them (FYI, even the `contents` doesn't currently work in PHP, it just read the number of bytes of it but no asserts are generated).

The PHP runtime doesn't currently throw any custom exceptions, only `RuntimeException`s. Throwing generic exceptions is generally discouraged, because if the surrounding code wants to distinguish the individual exceptions and choose how to handle them, it has to use some regexes on the message, which is ugly and will break when the message is changed. The generic exceptions shouldn't be used at all. So I added several additional custom exceptions as well.

All exceptions are in special files to comply with the [PSR-4 standard](https://www.php-fig.org/psr/psr-4/). To play well with autoloading in PHP, it's best to have only one class per file and the filename same as the class name.